### PR TITLE
Add regexp for mismatched indentations warning

### DIFF
--- a/lib/warning.rb
+++ b/lib/warning.rb
@@ -18,6 +18,7 @@ module Warning
       keyword_separation: /: warning: (?:Using the last argument (?:for `.+' )?as keyword parameters is deprecated; maybe \*\* should be added to the call|Passing the keyword argument (?:for `.+' )?as the last hash parameter is deprecated|Splitting the last argument (?:for `.+' )?into positional and keyword parameters is deprecated|The called method (?:`.+' )?is defined here)\n\z/,
       safe: /: warning: (?:rb_safe_level_2_warning|rb_safe_level|rb_set_safe_level_force|rb_set_safe_level|rb_secure|rb_insecure_operation|rb_check_safe_obj|\$SAFE) will (?:be removed|become a normal global variable) in Ruby 3\.0\n\z/,
       taint: /: warning: (?:rb_error_untrusted|rb_check_trusted|Pathname#taint|Pathname#untaint|rb_env_path_tainted|Object#tainted\?|Object#taint|Object#untaint|Object#untrusted\?|Object#untrust|Object#trust|rb_obj_infect|rb_tainted_str_new|rb_tainted_str_new_cstr) is deprecated and will be removed in Ruby 3\.2\.\n\z/,
+      mismatched_indentations: /: warning: mismatched indentations at '.+' with '.+' at \d+\n\z/,
     }
 
     # Clear all current ignored warnings, warning processors, and duplicate check cache.

--- a/test/fixtures/mismatched_indentations.rb
+++ b/test/fixtures/mismatched_indentations.rb
@@ -1,0 +1,4 @@
+# Example that will trigger the "mismatched indentations" warning from Ruby
+if 2 > 1
+  true
+    end

--- a/test/test_warning.rb
+++ b/test/test_warning.rb
@@ -351,6 +351,25 @@ class WarningTest < Minitest::Test
     end
   end
 
+  def test_warning_ignore_mismatched_indentation
+    assert_warning(/warning: mismatched indentations/) do
+      load 'test/fixtures/mismatched_indentations.rb'
+    end
+
+    fixture_filename = Pathname.new(File.dirname(__FILE__))
+                               .join('fixtures/mismatched_indentations.rb')
+                               .to_path
+
+    Warning.ignore(
+      :mismatched_indentations,
+      fixture_filename
+    )
+
+    assert_warning '' do
+      load fixture_filename
+    end
+  end
+
   def test_warning_process
     obj = Object.new
     warn = nil


### PR DESCRIPTION
Adds new regexp to capture warning messages (appeared in Ruby 2.7 I think? How to be sure?):
```
file/path.rb:xx: warning: mismatched indentations at 'end' with 'else' at 27
```

Couldn't get a test to work though, because it seems the warning is not emitted when code is run through `instance_eval`? At least that's what I gather from that test:
```ruby
def test_warning_ignore_mismatched_indentation
    def self.a; end
    assert_warning(/warning: mismatched indentations/) do
      instance_eval("if a\n  false\n    end", __FILE__)
    end

    Warning.ignore(:mismatched_indentations, __FILE__)

    assert_warning '' do
      instance_eval("if a\n  false\n    end", __FILE__)
    end
  end
```

failing with:
```
 1) Failure:
WarningTest#test_warning_ignore_mismatched_indentation [/home/mic/dev/oss/ruby-warning/test/test_warning.rb:356]:
--- expected
+++ actual
@@ -1 +1 @@
-/warning: mismatched indentations/
+""
```

But putting directly this in the block:
```ruby
assert_warning(/warning: mismatched indentations/) do
  if a
    false
      end
end
```
Ruby warns at top-level and not in the test:
```
/home/mic/dev/oss/ruby-warning/test/test_warning.rb:359: warning: mismatched indentations at 'end' with 'if' at 357
```