### PR TITLE
Fix typo in documentation comment

### DIFF
--- a/lib/warning.rb
+++ b/lib/warning.rb
@@ -126,7 +126,7 @@ module Warning
     # Instead of passing a block, you can pass a hash of actions to take for specific
     # warnings, using regexp as keys and a callable objects as values:
     #
-    #   Warning.ignore(__FILE__,
+    #   Warning.process(__FILE__,
     #     /instance variable @\w+ not initialized/ => proc do |warning|
     #       LOGGER.warning(warning)
     #     end,


### PR DESCRIPTION
The document is for `Warning.process`, but `Warning.ignore` is called unexpectedly in the document.