### PR TITLE
Allow ignore to accept a block for temporary ignores

### DIFF
--- a/lib/warning.rb
+++ b/lib/warning.rb
@@ -51,7 +51,7 @@ module Warning
       @process.freeze
       super
     end
-    
+
     # Ignore any warning messages matching the given regexp, if they
     # start with the given path.
     # The regexp can also be one of the following symbols (or an array including them), which will
@@ -94,10 +94,17 @@ module Warning
         raise TypeError, "first argument to Warning.ignore should be Regexp, Symbol, or Array of Symbols, got #{regexp.inspect}"
       end
 
-      synchronize do 
+      synchronize do
         @ignore << [path, regexp]
       end
-      nil
+      return unless block_given?
+
+      result = yield
+      synchronize do
+        index = @ignore.index [path, regexp]
+        @ignore.delete_at index unless index.nil?
+      end
+      result
     end
 
     # Handle all warnings starting with the given path, instead of

--- a/test/test_warning.rb
+++ b/test/test_warning.rb
@@ -108,6 +108,30 @@ class WarningTest < Minitest::Test
     end
   end
 
+  def test_warning_ignore_with_block
+    obj = Object.new
+
+    assert_warning(/instance variable @ivar3 not initialized/) do
+      Warning.ignore(/foo/) do
+        assert_nil(obj.instance_variable_get(:@ivar3))
+      end
+    end
+
+    assert_warning '' do
+      Warning.ignore(/instance variable @ivar3 not initialized/) do
+        assert_nil(obj.instance_variable_get(:@ivar3))
+      end
+    end
+
+    assert_warning(/instance variable @ivar3 not initialized/) do
+      Warning.ignore(/instance variable @ivar3 not initialized/) do
+        assert_nil(obj.instance_variable_get(:@ivar3))
+      end
+
+      assert_nil(obj.instance_variable_get(:@ivar3))
+    end
+  end
+
   def test_warning_ignore_missing_ivar
     Warning.clear
 


### PR DESCRIPTION
This PR adds the ability for `Warning.ignore` to accept a block and ignore the warning only when executing the block.

This should not modify any existing functionality of `ignore`. The method will still return `nil` unless a block is passed. However, if a block _is_ passed, the warning will be ignored _only_ while executing the block.

---

Here's an example. Say for my project I want to ignore all `:missing_ivar` warnings. I also have a method called `do_thing` that throws a `:mismatched_indentations` warning. I have decided that the mismatched indentation is necessary in that method, but I don't want the warning to be ignored everywhere.

I could do:

```ruby
Warning.ignore :missing_ivar

Warning.ignore :mismatched_indentations
do_thing
Warning.clear

# I want this to throw a :mismatched_indentation warning
# In this case, it works as expected
if true
  puts "true"
    end

# I don't want this to throw a :missing_ivar warning
# In this case, it doesn't work as expected
puts @foo
```

This doesn't work as I would need to re-ignore the `:missing_ivar` in order to continue ignoring as expected. This PR allows the following to work, instead:


```ruby
Warning.ignore :missing_ivar

Warning.ignore :mismatched_indentations do
  do_thing
end

# I want this to throw a :mismatched_indentation warning
# In this case, it works as expected
if true
  puts "true"
    end

# I don't want this to throw a :missing_ivar warning
# In this case, it works as expected
puts @foo
```
