### PR TITLE
Add missing Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /warning-*.gem
 /rdoc
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'rake'


### PR DESCRIPTION
Thanks for this useful gem 😄

When I tried to run tests in my local,  `bundle install` failed with a message `Could not locate Gemfile`.
My environment is `ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]` and `Bundler version 2.2.14`.
How do you run tests?

This change makes be able to run tests in my environment. 🤔