### PR TITLE
Fix other patterns of `void context`

### DIFF
--- a/lib/warning.rb
+++ b/lib/warning.rb
@@ -19,7 +19,7 @@ module Warning
       safe: /: warning: (?:rb_safe_level_2_warning|rb_safe_level|rb_set_safe_level_force|rb_set_safe_level|rb_secure|rb_insecure_operation|rb_check_safe_obj|\$SAFE) will (?:be removed|become a normal global variable) in Ruby 3\.0\n\z/,
       taint: /: warning: (?:rb_error_untrusted|rb_check_trusted|Pathname#taint|Pathname#untaint|rb_env_path_tainted|Object#tainted\?|Object#taint|Object#untaint|Object#untrusted\?|Object#untrust|Object#trust|rb_obj_infect|rb_tainted_str_new|rb_tainted_str_new_cstr) is deprecated and will be removed in Ruby 3\.2\.?\n\z/,
       mismatched_indentations: /: warning: mismatched indentations at '.+' with '.+' at \d+\n\z/,
-      void_context: /possibly useless use of :: in void context/,
+      void_context: /possibly useless use of (?:a )?\S+ in void context/,
     }
 
     # Map of action symbols to procs that return the symbol

--- a/test/test_warning.rb
+++ b/test/test_warning.rb
@@ -188,6 +188,28 @@ class WarningTest < Minitest::Test
     assert_warning '' do
       instance_eval('::Object; nil', __FILE__, __LINE__)
     end
+
+    assert_warning '' do
+      instance_eval('Object; nil', __FILE__, __LINE__)
+    end
+
+    assert_warning '' do
+      instance_eval('v = 0; v; nil', __FILE__, __LINE__)
+    end
+
+    assert_warning '' do
+      instance_eval('1 > 1; nil', __FILE__, __LINE__)
+    end
+
+    assert_warning '' do
+      instance_eval('defined? C; nil', __FILE__, __LINE__)
+    end
+
+    if RUBY_VERSION >= '2.6'
+      assert_warning '' do
+        instance_eval('1..; nil', __FILE__, __LINE__)
+      end
+    end
   end
 
   def test_warning_ignore_ambiguous_slash


### PR DESCRIPTION
I found other patterns of warnings around `void context`.
They looks defined at https://github.com/ruby/ruby/blob/2947ae3254c49e7861f29138df0b378fc81af14d/parse.y#L11392-L11474

This PR improves regex and adds some test cases.

NOTE
---

I didn't add some test cases for now they outputs other warning `unused literal ignored` together.

e.g

```console
$ ruby -v -w -e 'self; self'
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
-e:1: warning: unused literal ignored
-e:1: warning: possibly useless use of self in void context
```