### PR TITLE
Disallow Warning.process(Regexp, &block)

### DIFF
--- a/lib/warning.rb
+++ b/lib/warning.rb
@@ -144,6 +144,10 @@ module Warning
     #
     #   Warning.process(__FILE__, :missing_ivar=>:backtrace, :keyword_separation=>:raise)
     def process(path='', actions=nil, &block)
+      unless path.is_a?(String)
+        raise ArgumentError, "path must be a String not a #{path.class}"
+      end
+
       if block
         if actions
           raise ArgumentError, "cannot pass both actions and block to Warning.process"

--- a/test/test_warning.rb
+++ b/test/test_warning.rb
@@ -543,6 +543,13 @@ class WarningTest < Minitest::Test
     end
   end
 
+  def test_warning_process_path_no_string
+    e = assert_raises(ArgumentError) do
+      Warning.process(/foo/) { :raise }
+    end
+    assert_includes(e.message, "path must be a String not a Regexp")
+  end
+
   if RUBY_VERSION >= '3.0'
     def test_warning_warn_category_keyword
       assert_warning('foo') do


### PR DESCRIPTION
Fixes https://github.com/jeremyevans/ruby-warning/issues/17.

Previously, the following code worked by accident:

```ruby
  Warning.process(/foo/) { :raise }
```

Calling Warning.process a second time resulted in

```ruby
  # => ArgumentError (comparison of Regexp with Regexp failed)
```

This PR checks the type of passed path to be a String.