### PR TITLE
Add support for :standard_removal

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,6 +40,7 @@ appropriate regexp.  The supported symbols are:
 * :not_reached
 * :safe
 * :shadow
+* :standard_removal
 * :taint
 * :unused_var
 * :useless_operator

--- a/lib/warning.rb
+++ b/lib/warning.rb
@@ -14,6 +14,7 @@ module Warning
       missing_ivar: /: warning: instance variable @.+ not initialized\n\z/,
       not_reached: /: warning: statement not reached\n\z/,
       shadow: /: warning: shadowing outer local variable - \w+\n\z/,
+      standard_removal: /: warning: .+?\.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby [\d.]+\./,
       unused_var: /: warning: assigned but unused variable - \w+\n\z/,
       useless_operator: /: warning: possibly useless use of [><!=]+ in void context\n\z/,
       keyword_separation: /: warning: (?:Using the last argument (?:for [`'].+' )?as keyword parameters is deprecated; maybe \*\* should be added to the call|Passing the keyword argument (?:for [`'].+' )?as the last hash parameter is deprecated|Splitting the last argument (?:for [`'].+' )?into positional and keyword parameters is deprecated|The called method (?:[`'].+' )?is defined here)\n\z/,
@@ -106,6 +107,7 @@ module Warning
     # :not_reached :: Ignore statement not reached warnings.
     # :safe :: Ignore warnings related to $SAFE and related C-API functions.
     # :shadow :: Ignore warnings related to shadowing outer local variables.
+    # :standard_removal :: Ignore warnings that a gem will be removed from the standard library.
     # :taint :: Ignore warnings related to taint and related methods and C-API functions.
     # :unused_var :: Ignore warnings for unused variables.
     # :useless_operator :: Ignore warnings when using operators such as == and > when the

--- a/test/test_warning.rb
+++ b/test/test_warning.rb
@@ -475,6 +475,27 @@ class WarningTest < Minitest::Test
     end
   end
 
+  def test_warning_standard_removal
+    Warning.clear
+
+    gems_to_check = if RUBY_VERSION >= '3.3' && RUBY_VERSION < '3.4'
+        ['abbrev', 'csv']
+      else
+        nil
+      end
+    return unless gems_to_check
+
+    assert_warning(/gems since Ruby/) do
+      require gem_to_check[0]
+    end
+
+    Warning.ignore(:standard_removal, __FILE__)
+
+    assert_warning '' do
+      require gem_to_check[1]
+    end
+  end
+
   def test_warning_ignore_symbol_array
     def self.c; end
 


### PR DESCRIPTION
In ruby 3.3.0, a warning was added that [says](https://github.com/ruby/ruby/blob/v3_3_0/lib/bundled_gems.rb#L133) a gem will be removed (or has been removed) from the standard library and that it needs (or will need) to be required explicitly.

For example, in rails 7.2.1, ruby 3.3.5, this manifests as:

```
$ rails server
/home/vscode/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75: warning: /home/vscode/.rbenv/versions/3.3.5/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
Also please contact the author of jbuilder-2.12.0 to request adding ostruct into its gemspec.
=> Booting Puma
=> Rails 7.2.1 application starting...
```

There are multiple reasons one might want to silence this warning without actually adjusting one's gemspec.

One is that the warning may be spurious. Apparently the behavior shown above is [a bug in ruby 3.3.5](https://bugs.ruby-lang.org/issues/20737) and this warning will be silenced in 3.3.6.

Another is that the correct fix may be to wait for a future version of a dependency to change its behavior. In the rails case, its dependency jbuilder will [in future versions](https://github.com/rails/jbuilder/pull/567/files) stop requiring ostruct, which for many applications will solve the issue more cleanly.

So, this PR offers the option to silence this warning.

In my rails app it looks like this:

```
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,10 +1,13 @@
 require_relative "boot"
+require "warning"
 
 require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
+Warning.ignore(:standard_removal)
 Bundler.require(*Rails.groups)
+Warning.clear
...

$ rails server
=> Booting Puma
=> Rails 7.2.1 application starting...
```

I don't know if I wrote a good test. Probably not. I'm happy to address that or any other concerns if that will help.

And if this is too rare/small of a case to merit its own class of warnings, that's fine, please feel free to just close this PR. No hard feelings 😁 