### PR TITLE
Allow to customize the raised error

### DIFF
--- a/lib/warning.rb
+++ b/lib/warning.rb
@@ -32,6 +32,8 @@ module Warning
     }
     private_constant :ACTION_PROC_MAP
 
+    attr_accessor :error_class
+
     # Clear all current ignored warnings, warning processors, and duplicate check cache.
     # Also disables deduplicating warnings if that is currently enabled.
     #
@@ -261,7 +263,7 @@ module Warning
           #{super_}
           $stderr.puts caller
         when :raise
-          raise str
+          raise @error_class, str
         else
           # nothing
         end
@@ -295,6 +297,7 @@ module Warning
   @process = []
   @dedup = false
   @monitor = Monitor.new
+  @error_class = RuntimeError
 
   extend Processor
 end

--- a/test/test_warning.rb
+++ b/test/test_warning.rb
@@ -606,6 +606,22 @@ class WarningTest < Minitest::Test
     assert_match(/global variable [`']\$test_warning_process_block_return_backtrace' not initialized/, w)
   end
 
+  def test_warning_custom_error_class
+    error_class_was = Warning.error_class
+    Warning.error_class = Class.new(Exception)
+
+    Warning.process(__FILE__) do |warning|
+      :raise
+    end
+
+    error = assert_raises(Warning.error_class) do
+      $test_warning_process_block_return_raise
+    end
+    assert_match(/global variable [`']\$test_warning_process_block_return_raise' not initialized/, error.message)
+  ensure
+    Warning.error_class = error_class_was
+  end
+
   def test_warning_process_block_return_raise
     w = nil
     Warning.process(__FILE__) do |warning|


### PR DESCRIPTION
In some context, RuntimeError may not be the ideal error class to raise warnings.

For instance, in a test environment you may want to use an Exception subclass as to ensure warnings aren't swallowed by "blanket rescue" clauses.

Or in production you may want to use some error class with `Warning` in its name so that reports to the error tracker are better presented.