### PR TITLE
Automatically process anonymous evals too

### DIFF
--- a/lib/warning.rb
+++ b/lib/warning.rb
@@ -208,6 +208,7 @@ module Warning
 
       synchronize do
         @process << [path, block]
+        @process << ["(eval at #{path}", block] if RUBY_VERSION >= '3.3'
         @process.sort_by!(&:first)
         @process.reverse!
       end

--- a/test/test_warning.rb
+++ b/test/test_warning.rb
@@ -580,6 +580,23 @@ class WarningTest < Minitest::Test
     end
   end
 
+  if RUBY_VERSION >= '3.3'
+    def test_warning_process_eval_at
+      skip if RUBY_VERSION
+      warn = nil
+      Warning.process(__FILE__) do |warning|
+        warn = [1, warning]
+      end
+
+      mod = Module.new
+      mod.class_eval <<~RUBY
+        $test_warning_process
+      RUBY
+      assert_equal 1, warn.first
+      assert_match(/global variable [`']\$test_warning_process' not initialized/, warn.last)
+    end
+  end
+
   def test_warning_process_block_return_default
     w = nil
     Warning.process(__FILE__) do |warning|


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/19755

As of Ruby 3.3, code that was created using anonymous eval report its location with `"(eval at $PATH:$LINE)"`.

e.g. in my case:

```
(eval at .../gems/kt-paperclip-7.1.1/lib/paperclip/callbacks.rb:12):1: warning: method redefined; discarding old before_post_process
(eval at .../gems/kt-paperclip-7.1.1/lib/paperclip/callbacks.rb:12):1: warning: previous definition of before_post_process was here
(eval at .../gems/kt-paperclip-7.1.1/lib/paperclip/callbacks.rb:12):4: warning: method redefined; discarding old after_post_process
(eval at .../gems/kt-paperclip-7.1.1/lib/paperclip/callbacks.rb:12):4: warning: previous definition of after_post_process was here
```

I think it might make sense for `.process` to automatically filter these as well.